### PR TITLE
Add mobile clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ sudo ./pingtunnel -type server
 ```
 echo 1 > /proc/sys/net/ipv4/icmp_echo_ignore_all
 ```
+### Mobile client
+ - [iOS (Also Apple silicon)](https://apps.apple.com/app/ping-tunnel-vpn-over-icmp/id6748279683)
+ - [Android](https://play.google.com/store/apps/details?id=dev.hexasoftware.PingTunnel)
+
 
 ### Install the client
 
@@ -40,7 +44,6 @@ echo 1 > /proc/sys/net/ipv4/icmp_echo_ignore_all
 -   Then run with **administrator** privileges. The commands corresponding to different forwarding functions are as follows.
 -   If you see a log of ping pong, the connection is normal
 -   “-key” parameter is **int** type, only supports numbers between 0-2147483647
-
 
 #### Forward sock5
 


### PR DESCRIPTION
Add Mobile clients.

Additionally, we have created an [`installer.sh`](https://github.com/HexaSoftwareDev/PingTunnel-Server) script to simplify PingTunnel server setup by detecting OS and architecture, downloading the appropriate binary, and configuring a systemd service.
If acceptable, we would like to propose adding the installer to main repo in the next PR.

Thanks for your great work on this project.